### PR TITLE
Remove custom build of Kirigami Addons

### DIFF
--- a/org.kde.keysmith.json
+++ b/org.kde.keysmith.json
@@ -40,24 +40,6 @@
             ]
         },
         {
-            "name": "kirigami-addons",
-            "buildsystem": "cmake-ninja",
-            "builddir": true,
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-1.10.0.tar.xz",
-                    "sha256": "c98f92bf7c452e12f6dc403404215413db3959fe904ad830ead0db6bb09b3d11",
-                    "x-checker-data": {
-                        "type": "anitya",
-                        "project-id": 242933,
-                        "stable-only": true,
-                        "url-template": "https://download.kde.org/stable/kirigami-addons/kirigami-addons-$version.tar.xz"
-                    }
-                }
-            ]
-        },
-        {
             "name": "org.kde.keysmith",
             "buildsystem": "cmake-ninja",
             "config-opts": [


### PR DESCRIPTION
It's already included in the runtime.